### PR TITLE
Add alternative version that uses AudioContext

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,6 +15,13 @@ function prepend(message) {
 function useAudio(mediaStream) {
 	var audio = document.querySelector('audio');
 	audio.src = window.URL.createObjectURL(mediaStream);
+	// var context = new AudioContext();
+	// prepend('Audio context set up.');
+	// var microphone = context.createMediaStreamSource(mediaStream);
+	// var gain = context.createGain();
+	// microphone.connect(gain);
+	// gain.gain.value = 0.5;
+	// gain.connect(context.destination);
 	prepend("off you go...!");
 }
 


### PR DESCRIPTION
AudioContext is more configurable with filters and modifiers, however it can't be linked with the audio tag
